### PR TITLE
Support for data that is nested in a function/pipe

### DIFF
--- a/robust_summary.R
+++ b/robust_summary.R
@@ -42,7 +42,7 @@ summary.lm <- function (object, correlation = FALSE,
     if(length(cluster)>2){stop("The function only allows max. 2 clusters. You provided more.")}
     n_coef <- all.vars(object$call$formula)
     if(length(cluster)==1){
-      dat <- na.omit(eval(object$call$data) [,c(n_coef,cluster)])
+      dat <- na.omit(eval(object$call$data)[,c(n_coef,cluster)])
       if(nrow(dat)<nrow(object$model)){stop("Not all observation have a cluster.")}
       cluster_vector <- dat[,cluster]
       require(sandwich, quietly = TRUE)
@@ -55,12 +55,12 @@ summary.lm <- function (object, correlation = FALSE,
       rstdh <- sqrt(diag(varcovar))
     } 
     if(length(cluster)==2){
-      dat_1 <- na.omit(eval(object$call$data) [,c(n_coef,cluster[1])])
+      dat_1 <- na.omit(eval(object$call$data)[,c(n_coef,cluster[1])])
       if(nrow(dat_1)<nrow(object$model)){stop("Not all observation have a cluster.")}
-      dat_2 <- na.omit(eval(object$call$data) [,c(n_coef,cluster[2])])
+      dat_2 <- na.omit(eval(object$call$data)[,c(n_coef,cluster[2])])
       if(nrow(dat_2)<nrow(object$model)){stop("Not all observation have a cluster.")}
       
-      dat <- na.omit(eval(object$call$data) [,c(n_coef,cluster)])
+      dat <- na.omit(eval(object$call$data)[,c(n_coef,cluster)])
       library(sandwich,quietly = TRUE)
       cluster1 <- dat[,cluster[1]]
       cluster2 <- dat[,cluster[2]]

--- a/robust_summary.R
+++ b/robust_summary.R
@@ -42,7 +42,7 @@ summary.lm <- function (object, correlation = FALSE,
     if(length(cluster)>2){stop("The function only allows max. 2 clusters. You provided more.")}
     n_coef <- all.vars(object$call$formula)
     if(length(cluster)==1){
-      dat <- na.omit(get(paste(object$call$data))[,c(n_coef,cluster)])
+      dat <- na.omit(eval(object$call$data) [,c(n_coef,cluster)])
       if(nrow(dat)<nrow(object$model)){stop("Not all observation have a cluster.")}
       cluster_vector <- dat[,cluster]
       require(sandwich, quietly = TRUE)
@@ -55,12 +55,12 @@ summary.lm <- function (object, correlation = FALSE,
       rstdh <- sqrt(diag(varcovar))
     } 
     if(length(cluster)==2){
-      dat_1 <- na.omit(get(paste(object$call$data))[,c(n_coef,cluster[1])])
+      dat_1 <- na.omit(eval(object$call$data) [,c(n_coef,cluster[1])])
       if(nrow(dat_1)<nrow(object$model)){stop("Not all observation have a cluster.")}
-      dat_2 <- na.omit(get(paste(object$call$data))[,c(n_coef,cluster[2])])
+      dat_2 <- na.omit(eval(object$call$data) [,c(n_coef,cluster[2])])
       if(nrow(dat_2)<nrow(object$model)){stop("Not all observation have a cluster.")}
       
-      dat <- na.omit(get(paste(object$call$data))[,c(n_coef,cluster)])
+      dat <- na.omit(eval(object$call$data) [,c(n_coef,cluster)])
       library(sandwich,quietly = TRUE)
       cluster1 <- dat[,cluster[1]]
       cluster2 <- dat[,cluster[2]]

--- a/use_demo.R
+++ b/use_demo.R
@@ -1,0 +1,17 @@
+setwd("/Users/williamlief/Documents/github/economictheoryblog")
+source("robust_summary.R")
+
+library(dplyr)
+
+data("iris")
+iris.subset <- filter(iris, Petal.Width < 1.2)
+
+
+m0 <- lm(Sepal.Length ~ Sepal.Width, data = iris.subset)
+m1 <- lm(Sepal.Length ~ Sepal.Width, data = iris %>% filter(Petal.Width < 1.2))
+m2 <- lm(Sepal.Length ~ Sepal.Width, data = filter(iris, Petal.Width < 1.2))
+
+
+summary(m0, cluster = c("Species"))
+summary(m1, cluster = c("Species"))
+summary(m2, cluster = c("Species"))


### PR DESCRIPTION
Very minor modification to the call to the original model data. This code supports lm objects that are created with data that is nested in a function call or pipe. This obviates the need for lazy users to create a subsetted dataframe before running the lm model.

### Example Use ###
source("robust_summary.R")
library(dplyr)
data("iris")

# subsetting before model call
iris.subset <- filter(iris, Petal.Width < 1.2) 
m0 <- lm(Sepal.Length ~ Sepal.Width, data = iris.subset) 

# subsetting in model, with pipe and function nesting
m1 <- lm(Sepal.Length ~ Sepal.Width, data = iris %>% filter(Petal.Width < 1.2))
m2 <- lm(Sepal.Length ~ Sepal.Width, data = filter(iris, Petal.Width < 1.2))

# Original code errors on m1 and m2
summary(m0, cluster = c("Species"))
summary(m1, cluster = c("Species"))
summary(m2, cluster = c("Species"))